### PR TITLE
ignore build bits and add link to project page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.lock-wscript

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name":		"uname",
 	"version":	"0.0.1",
 	"description":	"SUSv3 uname binding",
+	"homepage":	"https://github.com/davepacheco/node-uname",
 	"author":	"Dave Pacheco (dap@cs.brown.edu)",
 	"engines":	{ "node": "*" },
 	"main":		"./build/default/uname",


### PR DESCRIPTION
To facilitate mountain-gorilla builds of CA that use this as a git submodule.

Without this the CA repo is always "dirty" after a build:

```
$ git status
...
#       modified:   deps/node-uname
...
```
